### PR TITLE
Use nginx for production build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,74 +1,23 @@
-# Usa Node.js 20 (amd64) como base
-FROM --platform=linux/amd64 node:20
-
-# Establecer directorio de trabajo
+# Build stage: use Node.js to build Angular app
+FROM --platform=linux/amd64 node:20 AS build
 WORKDIR /app
 
-# Define un argumento para elegir la estrategia de instalación (por defecto, npm ci)
+# Whether to use npm ci
 ARG USE_NPM_CI=true
 
-# Copiar los archivos de dependencia antes que el resto para aprovechar la caché
+# Copy package files and install dependencies
 COPY package*.json ./
+RUN npm install -g @angular/cli --save-dev
+RUN if [ "$USE_NPM_CI" = "true" ]; then npm ci; else npm install; fi
 
-RUN npm install -g @angular/cli --save-dev 
-
-#COPY . .
-# Instalar dependencias según el argumento:
-# Si USE_NPM_CI es "true" se usará npm ci, de lo contrario npm install.
-RUN if [ "$USE_NPM_CI" = "true" ]; then \
-        npm ci; \ 
-    else \
-        npm install; \
-    fi
-
-# Instalar Angular CLI globalmente (opcional, si lo necesitas para ng serve)
-
-# Copiar el resto de la aplicacións
+# Copy source and build for production
 COPY . .
+RUN ng build --configuration production
 
-RUN if [ "$USE_NPM_CI" = "true" ]; then \
-    npx ng build --configuration production; \
-    fi
+# Runtime stage: serve with Nginx
+FROM nginx:alpine
+COPY --from=build /app/dist/recepcion-fondos-publicos /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
-
-# Exponer el puerto donde se levantará el servidor de desarrollo (4200)
-EXPOSE 4200
-
-CMD ["ng", "serve", "--host", "0.0.0.0", "--poll=2000"]
-
-
-
-# FROM --platform=linux/amd64 node:20
-
-# WORKDIR /app
-
-# ARG USE_NPM_CI=true
-
-# # 1. Copiar solo archivos de dependencias primero
-# COPY package*.json ./
-
-# # 2. Instalar Angular CLI y dependencias
-# RUN npm install -g @angular/cli
-
-# # 3. Instalación condicional y build
-# RUN if [ "$USE_NPM_CI" = "true" ]; then \
-#         npm ci; \
-#         ng build --configuration production --output-hashing none; \
-#     else \
-#         npm install; \
-#     fi
-
-# # 4. Copiar el resto del código (IMPORTANTE: debe ir después del build si usas CI)
-# COPY . .
-
-# # 5. Exponer y ejecutar
-# EXPOSE 4200
-# CMD ["ng", "serve", "--host", "0.0.0.0", "--poll=2000"]
-
-
-####
-#Advertencia importante: Si usas USE_NPM_CI=true, el COPY . . debe ir DESPUÉS del build porque:
- #   Primero instalas dependencias
- #   Luego haces el build con el código que ya estaba en el contexto del Dockerfile
- #   Finalmente copias el código nuevo
-###
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -25,4 +25,14 @@ Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To u
 ## Further help
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
-# pvangularfront
+
+## Docker with Nginx
+
+A `Dockerfile` is provided to build the project and serve the production build through **Nginx**. Build the image and run it with:
+
+```bash
+docker build -t rfp-app .
+docker run -p 8080:80 rfp-app
+```
+
+The application will be available on [http://localhost:8080](http://localhost:8080).

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- serve production build with nginx via multistage Dockerfile
- document docker usage with nginx in README
- add nginx.conf for SPA routing

## Testing
- `npm test --silent --unsafe-perm` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6881384105508321b5d6a0911d257377