### PR TITLE
Limit numeric inputs

### DIFF
--- a/src/app/ComponenteReceptores/crear-ficha/crear-ficha.component.html
+++ b/src/app/ComponenteReceptores/crear-ficha/crear-ficha.component.html
@@ -106,6 +106,7 @@
             <div class="col-md-4">
               <label for="patrimonio" class="form-label">Patrimonio</label>
               <input appValidacionesInput
+                [appMax]="99000000" [appMin]="0"
                 type="text"
                 id="patrimonio"
                 class="form-control"
@@ -119,6 +120,7 @@
               <div class="form-group">
                 <label for="capitalSocial" class="form-label">Capital social</label>
                 <input appValidacionesInput
+                  [appMax]="99000000" [appMin]="0"
                   type="text"
                   id="capitalSocial"
                   class="form-control"
@@ -133,6 +135,7 @@
               <div class="form-group">
                 <label for="estadoResultado" class="form-label">Estado Resultado</label>
                 <input appValidacionesInput
+                  [appMax]="99000000" [appMin]="0"
                   type="text"
                   id="estadoResultado"
                   class="form-control"

--- a/src/app/directivas/validaciones-input.directive.ts
+++ b/src/app/directivas/validaciones-input.directive.ts
@@ -9,11 +9,25 @@ import { Directive, HostListener, ElementRef, Input } from '@angular/core';
   standalone: true
 })
 export class ValidacionesInputDirective {
+  @Input() appMax?: number;
+  @Input() appMin?: number;
+
   @HostListener('input', ['$event'])
   onInput(event: Event): void {
     const input = event.target as HTMLInputElement;
 
-    const limpio = input.value.replace(/\D/g, '');
+    let limpio = input.value.replace(/\D/g, '');
+
+    if (limpio) {
+      let valor = parseInt(limpio, 10);
+      if (this.appMax != null && valor > this.appMax) {
+        valor = this.appMax;
+      }
+      if (this.appMin != null && valor < this.appMin) {
+        valor = this.appMin;
+      }
+      limpio = String(valor);
+    }
 
     if (input.value !== limpio) {
       input.value = limpio;


### PR DESCRIPTION
## Summary
- restrict values in Crear Ficha to the 0-99,000,000 range
- extend `appValidacionesInput` directive with optional min/max inputs

## Testing
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_688243e29518832193f52127f3c36007