### PR TITLE
Limit numeric fields to 8 digits

### DIFF
--- a/src/app/ComponenteReceptores/crear-ficha/crear-ficha.component.html
+++ b/src/app/ComponenteReceptores/crear-ficha/crear-ficha.component.html
@@ -106,7 +106,7 @@
             <div class="col-md-4">
               <label for="patrimonio" class="form-label">Patrimonio</label>
               <input appValidacionesInput
-                [appMax]="99000000" [appMin]="0"
+                [appMaxLength]="8"
                 type="text"
                 id="patrimonio"
                 class="form-control"
@@ -120,7 +120,7 @@
               <div class="form-group">
                 <label for="capitalSocial" class="form-label">Capital social</label>
                 <input appValidacionesInput
-                  [appMax]="99000000" [appMin]="0"
+                  [appMaxLength]="8"
                   type="text"
                   id="capitalSocial"
                   class="form-control"
@@ -135,7 +135,7 @@
               <div class="form-group">
                 <label for="estadoResultado" class="form-label">Estado Resultado</label>
                 <input appValidacionesInput
-                  [appMax]="99000000" [appMin]="0"
+                  [appMaxLength]="8"
                   type="text"
                   id="estadoResultado"
                   class="form-control"

--- a/src/app/directivas/validaciones-input.directive.ts
+++ b/src/app/directivas/validaciones-input.directive.ts
@@ -11,12 +11,18 @@ import { Directive, HostListener, ElementRef, Input } from '@angular/core';
 export class ValidacionesInputDirective {
   @Input() appMax?: number;
   @Input() appMin?: number;
+  /** Máximo número de dígitos permitidos */
+  @Input() appMaxLength?: number;
 
   @HostListener('input', ['$event'])
   onInput(event: Event): void {
     const input = event.target as HTMLInputElement;
 
     let limpio = input.value.replace(/\D/g, '');
+
+    if (this.appMaxLength != null && limpio.length > this.appMaxLength) {
+      limpio = limpio.slice(0, this.appMaxLength);
+    }
 
     if (limpio) {
       let valor = parseInt(limpio, 10);


### PR DESCRIPTION
## Summary
- extend `ValidacionesInputDirective` with `appMaxLength` to limit numeric input length
- restrict Patrimonio, Capital Social and Estado Resultado fields to 8 digits

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: authGuard spec import error)*

------
https://chatgpt.com/codex/tasks/task_e_68824ae2f30083219075f8ed2848a5e6