### PR TITLE
Fix user name display

### DIFF
--- a/src/app/ComponenteReceptores/cabecera-logged/cabecera-logged.component.ts
+++ b/src/app/ComponenteReceptores/cabecera-logged/cabecera-logged.component.ts
@@ -27,10 +27,12 @@ export class CabeceraLoggedComponent {
     if (u) {
       const datosPersonal = u.respuesta_xml?.documento?.datosPersonal;
       if (datosPersonal?.nombre?.nombres) {
-        const nombres = datosPersonal.nombre.nombres.trim();
+        const primerNombre = datosPersonal.nombre.nombres
+          .trim()
+          .split(/\s+/)[0];
         const apPaterno = datosPersonal.nombre.apellidoPaterno || '';
         const apMaterno = datosPersonal.nombre.apellidoMaterno || '';
-        this.nombreUsuario = `${nombres} ${apPaterno} ${apMaterno}`.trim();
+        this.nombreUsuario = `${primerNombre} ${apPaterno} ${apMaterno}`.trim();
       } else {
         this.nombreUsuario = u.rut_enviado;
       }


### PR DESCRIPTION
## Summary
- only show the user's first name followed by both surnames

## Testing
- `npm test` *(fails: Chrome browser not found)*

------
https://chatgpt.com/codex/tasks/task_e_68825c8e6f1883218fd35a281ce54c7d