### PR TITLE
Limit text length on Ficha creation form

### DIFF
--- a/src/app/ComponenteReceptores/crear-ficha/crear-ficha.component.html
+++ b/src/app/ComponenteReceptores/crear-ficha/crear-ficha.component.html
@@ -23,7 +23,16 @@
             <div class="col-md-4">
               <div class="form-group">
                 <label for="razonSocial" class="form-label">Razón Social</label>
-                <input type="text" id="razonSocial" class="form-control" placeholder="Municipalidad de Santiago"  [(ngModel)]="razonSocial" name="razonSocial" />
+                <input
+                  type="text"
+                  id="razonSocial"
+                  class="form-control"
+                  placeholder="Municipalidad de Santiago"
+                  [(ngModel)]="razonSocial"
+                  name="razonSocial"
+                  appLimitarTexto
+                  [attr.maxLength]="200"
+                />
               </div>
             </div>
             <div class="col-md-4">
@@ -77,8 +86,15 @@
             <div class="col">
               <div class="form-group">
                 <label for="areaTematica" class="form-label">Área Temática</label>
-                <textarea id="areaTematica" class="form-control" rows="2" [(ngModel)]="areaTematica"
-                name="areaTematica"></textarea>
+                <textarea
+                  id="areaTematica"
+                  class="form-control"
+                  rows="2"
+                  [(ngModel)]="areaTematica"
+                  name="areaTematica"
+                  appLimitarTexto
+                  [attr.maxLength]="200"
+                ></textarea>
               </div>
             </div>
           </div>

--- a/src/app/ComponenteReceptores/crear-ficha/crear-ficha.component.ts
+++ b/src/app/ComponenteReceptores/crear-ficha/crear-ficha.component.ts
@@ -4,6 +4,7 @@ import { FichaService } from '../../services/ficha.service';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ValidacionesInputDirective, ValidarRutDirective } from '../../directivas/validaciones-input.directive';
+import { LimitarTextoDirective } from '../../directivas/limitar-texto.directive';
 
 interface ArchivoWrapper {
   file?: File;   // presente cuando se acaba de seleccionar
@@ -14,7 +15,8 @@ interface ArchivoWrapper {
   standalone: true,
   imports: [CommonModule, FormsModule,
     ValidacionesInputDirective,
-    ValidarRutDirective],
+    ValidarRutDirective,
+    LimitarTextoDirective],
   templateUrl: './crear-ficha.component.html',
   styleUrls: ['./crear-ficha.component.css']
 })

--- a/src/app/directivas/limitar-texto.directive.ts
+++ b/src/app/directivas/limitar-texto.directive.ts
@@ -1,0 +1,40 @@
+import { Directive, HostListener, Input } from '@angular/core';
+
+/**
+ * Limita la cantidad de caracteres permitidos y filtra algunos caracteres especiales.
+ */
+@Directive({
+  selector: '[appLimitarTexto]',
+  standalone: true
+})
+export class LimitarTextoDirective {
+  /** Máximo número de caracteres permitidos */
+  @Input() appLimitarTexto = 200;
+
+  /**
+   * Expresión regular con los caracteres que NO estarán permitidos.
+   * Por defecto se excluyen caracteres especiales comunes como < > { }.
+   */
+  @Input() appLimitarTextoExcluir: RegExp = /[<>\{\}]/g;
+
+  @HostListener('input', ['$event'])
+  onInput(event: Event): void {
+    const input = event.target as HTMLInputElement | HTMLTextAreaElement;
+    let valor = input.value;
+
+    // Filtrar caracteres no permitidos
+    if (this.appLimitarTextoExcluir) {
+      valor = valor.replace(this.appLimitarTextoExcluir, '');
+    }
+
+    // Limitar longitud
+    if (valor.length > this.appLimitarTexto) {
+      valor = valor.slice(0, this.appLimitarTexto);
+    }
+
+    if (input.value !== valor) {
+      input.value = valor;
+      input.dispatchEvent(new Event('input'));
+    }
+  }
+}

--- a/src/app/guards/auth.guard.spec.ts
+++ b/src/app/guards/auth.guard.spec.ts
@@ -1,17 +1,16 @@
 import { TestBed } from '@angular/core/testing';
-import { CanActivateFn } from '@angular/router';
 
-import { authGuard } from './auth.guard';
+import { AuthGuard } from './auth.guard';
 
-describe('authGuard', () => {
-  const executeGuard: CanActivateFn = (...guardParameters) => 
-      TestBed.runInInjectionContext(() => authGuard(...guardParameters));
+describe('AuthGuard', () => {
+  let guard: AuthGuard;
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
+    guard = TestBed.inject(AuthGuard);
   });
 
   it('should be created', () => {
-    expect(executeGuard).toBeTruthy();
+    expect(guard).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- add `LimitarTextoDirective` to filter special chars and limit length
- apply directive to "razonSocial" input and "areaTematica" textarea
- wire directive into `CrearFichaComponent`
- fix AuthGuard unit test

## Testing
- `npx ng test --watch=false` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_688284a017008321b235d1fe09a2dbde