### PR TITLE
Add custom names for optional attachments

### DIFF
--- a/src/app/ComponenteReceptores/crear-ficha/crear-ficha.component.html
+++ b/src/app/ComponenteReceptores/crear-ficha/crear-ficha.component.html
@@ -218,6 +218,14 @@
     <!-- Lista dinámica de slots “otroX” -->
     <div *ngFor="let otro of archivosOtros" class="mb-2">
       <label class="form-label">{{ otro.label }}</label>
+      <input
+        type="text"
+        class="form-control mb-2"
+        [id]="otro.key + '_nombre'"
+        [(ngModel)]="otro.nombre"
+        appLimitarTexto="100"
+        placeholder="Nombre del archivo"
+      />
 
       <div class="row w-100 mb-2">
         <!-- Input oculto + botón seleccionar -->


### PR DESCRIPTION
## Summary
- add `OtroArchivo` interface for optional files
- allow entering a custom name for each optional file slot
- validate custom names in the form
- persist optional files using the provided name

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6887a6f5096883218a2ea3bb46d9d11d