### PR TITLE
Add sorting buttons for region and date columns

### DIFF
--- a/src/app/components/tabla-data/tabla-data.component.html
+++ b/src/app/components/tabla-data/tabla-data.component.html
@@ -21,11 +21,21 @@
         <tr>
             <th>RUT</th>
             <th>Razón Social</th>
-            <th>Región</th>
+            <th>
+              <button type="button" class="btn btn-link p-0 me-1" (click)="toggleSort('region')">
+                <span [innerHTML]="sortDirection.region === 'asc' ? '&#9650;' : '&#9660;'"></span>
+              </button>
+              Región
+            </th>
             <th>Tipo de Empresa</th>
             <th>Representante Legal</th>
             <th>Contacto</th>
-            <th>Fecha Certif.</th>
+            <th>
+              <button type="button" class="btn btn-link p-0 me-1" (click)="toggleSort('fecha')">
+                <span [innerHTML]="sortDirection.fecha === 'asc' ? '&#9650;' : '&#9660;'"></span>
+              </button>
+              Fecha Certif.
+            </th>
         </tr>
     </thead>
     <tbody>

--- a/src/app/components/tabla-data/tabla-data.component.ts
+++ b/src/app/components/tabla-data/tabla-data.component.ts
@@ -20,6 +20,11 @@ import * as FileSaver from 'file-saver';
 export class TablaDataComponent implements OnInit {
   personas: PersonaJuridica[] = [];
   dataTableInitialized = false;
+  dataTable: any;
+  sortDirection: Record<'region' | 'fecha', 'asc' | 'desc'> = {
+    region: 'asc',
+    fecha: 'asc'
+  };
 
   constructor(private apiService: ApirestIndapService) {}
 
@@ -61,8 +66,8 @@ export class TablaDataComponent implements OnInit {
       if (this.dataTableInitialized) {
         $('#fichasReceptores').DataTable().destroy(); // Destruir antes de reiniciar
       }
-  
-      $('#fichasReceptores').DataTable({
+
+      this.dataTable = $('#fichasReceptores').DataTable({
         searching: true,
         paging: true,
         responsive: true,
@@ -81,8 +86,18 @@ export class TablaDataComponent implements OnInit {
           }
         }
       });
-  
+
       this.dataTableInitialized = true;
     }, 0);
+  }
+
+  toggleSort(column: 'region' | 'fecha'): void {
+    if (!this.dataTable) {
+      return;
+    }
+    const index = column === 'region' ? 2 : 6;
+    const direction = this.sortDirection[column] === 'asc' ? 'desc' : 'asc';
+    this.sortDirection[column] = direction;
+    this.dataTable.order([index, direction]).draw();
   }
 }


### PR DESCRIPTION
## Summary
- enable sorting with buttons for Region and Fecha Certif. columns
- keep track of sort direction and apply ordering through DataTables API

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome)*
- `npm run build --silent` *(fails: NG2 template errors in CrearFichaComponent)*

------
https://chatgpt.com/codex/tasks/task_e_6887d62d93008321bc207a214deae83a