### PR TITLE
feat: add registro 19862 certificate upload

### DIFF
--- a/src/app/ComponenteReceptores/crear-ficha/crear-ficha.component.html
+++ b/src/app/ComponenteReceptores/crear-ficha/crear-ficha.component.html
@@ -278,6 +278,31 @@
 </div>
 
 
+          <!-- Aviso importante -->
+          <div class="alert alert-warning" role="alert">
+            La persona jurídica debe estar inscrita en el
+            <strong>Registro Nacional de Receptores de Fondos Públicos</strong> del Ministerio de Hacienda.
+            Puede buscar el perfil en&nbsp;
+            <a href="https://www.registros19862.cl/certificado/institucion"
+               target="_blank" rel="noopener">
+              https://www.registros19862.cl/certificado/institucion
+            </a>.
+          </div>
+
+          <!-- Subida de Certificado Registro 19862 -->
+          <div class="mb-4">
+            <label for="certificado" class="form-label fw-bold">Certificado Registro 19862</label>
+            <input type="file"
+                   class="form-control"
+                   id="certificado"
+                   (change)="onFileChange($event)">
+            <button class="btn btn-dark mt-2"
+                    [disabled]="subiendo || !selectedFile"
+                    (click)="subirCertificado()">
+              {{ subiendo ? 'Subiendo…' : 'Subir' }}
+            </button>
+            <div class="mt-2" *ngIf="mensaje">{{ mensaje }}</div>
+          </div>
           <hr>
 
 

--- a/src/app/ComponenteReceptores/crear-ficha/crear-ficha.component.ts
+++ b/src/app/ComponenteReceptores/crear-ficha/crear-ficha.component.ts
@@ -102,6 +102,11 @@ export class CrearFichaComponent implements OnInit{
   // Estructura donde guardamos los archivos seleccionados
   archivosSeleccionados: { [key: string]: ArchivoWrapper | undefined } = {};
 
+  // Manejo de certificado Registro 19862
+  selectedFile: File | null = null;
+  subiendo = false;
+  mensaje = '';
+
   constructor(
     private router: Router,
     private fichaService: FichaService,
@@ -416,6 +421,36 @@ export class CrearFichaComponent implements OnInit{
           this.fichaService.setArchivos(key, wrapper.file, label);
         }
       });
+  }
+
+  onFileChange(event: Event) {
+    const input = event.target as HTMLInputElement;
+    if (input.files && input.files.length) {
+      this.selectedFile = input.files[0];
+      this.mensaje = '';
+    }
+  }
+
+  subirCertificado() {
+    if (!this.selectedFile || this.subiendo) { return; }
+
+    this.subiendo = true;
+    try {
+      this.fichaService.setArchivos(
+        'certificadoRegistro19862',
+        this.selectedFile,
+        'Certificado Registro 19862'
+      );
+      this.mensaje = '✅ Certificado cargado correctamente';
+      this.selectedFile = null;
+      const inputEl = document.getElementById('certificado') as HTMLInputElement | null;
+      if (inputEl) { inputEl.value = ''; }
+    } catch (err) {
+      console.error(err);
+      this.mensaje = '❌ Error al cargar el certificado';
+    } finally {
+      this.subiendo = false;
+    }
   }
 
   irCrearFichaparteii() {


### PR DESCRIPTION
## Summary
- show warning and upload control for Registro 19862 certificate in crear-ficha
- handle certificate selection and persistence in component

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_688b8701b97483219de79659a900ffe6